### PR TITLE
Remove MyPlot dependency

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -5,7 +5,6 @@ api: [3.0.0]
 author: Enes5519
 fixer: WolfTubeTM
 forker: Wertzui123
-depend: [MyPlot]
 
 permissions:
   playerhead:

--- a/src/Enes5519/PlayerHead/PlayerHead.php
+++ b/src/Enes5519/PlayerHead/PlayerHead.php
@@ -72,9 +72,9 @@ class PlayerHead extends PluginBase implements Listener
     {
         $player = $event->getPlayer();
         $position = $player->getPosition();
-        $plot = $player->getServer()->getPluginManager()->getPlugin("MyPlot")->getPlotByPosition($position);
+
         if ($player->hasPermission("cb-heads.spawn") and ($item = $player->getInventory()->getItemInHand())->getId() == Item::MOB_HEAD) {
-                        if(($plot !== null && $plot->owner == $player->getName()) || ($plot !== null && in_array($pname, $plot->helpers)) || ($plot !== null && in_array("*", $plot->helpers)) || $player->hasPermission("myplot.admin.build")){
+            if(!$event->isCancelled()){
                 $blockData = $item->getCustomBlockData() ?? new CompoundTag();
                 $skin = $blockData->getCompoundTag("Skin");
                 if ($skin !== null) {

--- a/src/Enes5519/PlayerHead/entities/HeadEntity.php
+++ b/src/Enes5519/PlayerHead/entities/HeadEntity.php
@@ -27,8 +27,11 @@ declare(strict_types=1);
 namespace Enes5519\PlayerHead\entities;
 
 use Enes5519\PlayerHead\PlayerHead;
+use pocketmine\block\BlockFactory;
+use pocketmine\block\BlockIds;
 use pocketmine\entity\Human;
 use pocketmine\entity\Skin;
+use pocketmine\event\block\BlockBreakEvent;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\nbt\tag\CompoundTag;
@@ -64,14 +67,18 @@ class HeadEntity extends Human
     {
         if ($source instanceof EntityDamageByEntityEvent and $source->getDamager() instanceof Player) {
             $player = $source->getDamager();
-            $pname = $player->getName();
-            $plot = $player->getServer()->getPluginManager()->getPlugin("MyPlot")->getPlotByPosition($this);
 
             if ($player->hasPermission("cb-heads.kill")) {
-                            if(($plot !== null && $plot->owner == $player->getName()) || ($plot !== null && in_array($pname, $plot->helpers)) || ($plot !== null && in_array("*", $plot->helpers)) || $player->hasPermission("myplot.admin.build")){
+                $pos = $this->asPosition();
+                $pos->x = $pos->getFloorX();
+                $pos->y = $pos->getFloorY();
+                $pos->z = $pos->getFloorZ();
+                $block = BlockFactory::get(BlockIds::SKULL_BLOCK, 0, $pos);
 
+                ($event = new BlockBreakEvent($player, $block, $player->getInventory()->getItemInHand(), false, $this->getDrops()))->call();
+
+                if(!$event->isCancelled()){
                     parent::attack($source);
-
                 }
             }
         }


### PR DESCRIPTION
This pr removes the MyPlot dependency of the plugin and instead offers a similar, perhaps improved, behaviour when heads are placed/broken.

Placement simply checks if the event was cancelled. MyPlot cancels it when necessary.

Breaking/Hitting the head fires BlockBreakEvent and then checks if it was cancelled. Again, MyPlot cancels it when necessary.